### PR TITLE
fix add span for dropdown-header link

### DIFF
--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -153,7 +153,8 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			 * if there is a value in the attr_title property. If the attr_title
 			 * property is NOT null we apply it as the class name for the icon
 			 */
-			if ( ! empty( $item->attr_title ) ){
+			if ( ( ! empty( $item->attr_title ) ) && (strcasecmp( $item->attr_title, 'dropdown-header') !== 0)){
+
 				$item_output .= '<span class="' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';
 			}
 


### PR DESCRIPTION
Prior to patch the menu looked so

<table>
<tr>
  <td rowspan=2>Home</td>
 <td></td>
 <td rowspan=2>About</td>
<tr>
  <td>dropdown-header</td>

</tr>
</table>
